### PR TITLE
Update heyoka dependency in kep3_devel.yml

### DIFF
--- a/kep3_devel.yml
+++ b/kep3_devel.yml
@@ -8,7 +8,7 @@ dependencies:
   - cmake >=3.18
   - boost-cpp >=1.73
   - fmt
-  - heyoka >=0.21.0
+  - heyoka =2.*
   - spdlog
   - xtensor
   - xtensor-blas


### PR DESCRIPTION
heyoka has now switched to a semantic versioning scheme, so let us be specific about the heyoka API version being used by kep3.